### PR TITLE
Ajout d'un README principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Stadi
+
+Stadi est un outil de création de builds pour **Overwatch 2** dans son mode **Stadium**. Ce dépôt réunit une API Symfony et une application Vue 3 permettant de gérer les données et l'interface utilisateur nécessaires à la composition des builds.
+
+## Fonctionnalités principales
+- Création et gestion de builds pour OW2 Stadium.
+- Backend API en **Symfony 7.3** (PHP 8.3).
+- Frontend en **Vue 3** propulsé par **Vite**.
+- Environnement de développement conteneurisé avec **DDEV**, incluant Node 22 et MariaDB 10.11.
+- Tests unitaires via **Vitest** et tests end‑to‑end via **Cypress**.
+
+## Structure du projet
+- `backend/` : code de l’API Symfony.
+- `webapp/` : application Vue 3 générée par Vite.
+- `.ddev/` : configuration DDEV pour lancer les conteneurs locaux.
+- `Makefile` : raccourcis pour l’installation, le démarrage et diverses tâches.
+
+## Installation
+1. Installez les dépendances en lançant :
+   ```bash
+   make install
+   ```
+   Cette commande démarre DDEV, installe les dépendances PHP avec Composer puis les dépendances Node de l’interface.
+2. Une fois l’installation terminée, les URL de développement sont affichées :
+   - API : `https://stadi.ddev.site`
+   - Frontend : `https://app.stadi.ddev.site`
+
+## Développement
+- Lancer l’environnement complet et le serveur de développement :
+  ```bash
+  make up
+  ```
+- Accéder à un shell dans le conteneur principal :
+  ```bash
+  make ssh
+  ```
+
+Les variables d’environnement par défaut (base de données, serveur SMTP, etc.) sont définies dans le fichier `.env.local`.
+
+## Tests
+Dans `webapp/` :
+- Exécuter les tests unitaires :
+  ```bash
+  npm run test:unit -- --run
+  ```
+- Lancer les tests end‑to‑end :
+  ```bash
+  npm run test:e2e
+  ```
+
+## Construction pour la production
+- Construire l’interface Vue :
+  ```bash
+  npm run build
+  ```
+
+## Contributions
+Les issues et pull requests sont les bienvenues pour améliorer l’outil et ajouter de nouvelles fonctionnalités autour des builds Stadium d’Overwatch 2.


### PR DESCRIPTION
## Summary
- add root README in French describing the Stadi project and how to run it

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e -b chrome` *(fails: start-server-and-test stalled)*

------
https://chatgpt.com/codex/tasks/task_e_6841462f29e8832ea73a27d0bbda0711