### PR TITLE
Add entities and CRUD actions for Stadium builds

### DIFF
--- a/backend/src/Controller/Ability/CreateAbilityController.php
+++ b/backend/src/Controller/Ability/CreateAbilityController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Controller\Ability;
+
+use App\Entity\Ability;
+use App\Repository\HeroRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CreateAbilityController extends AbstractController
+{
+    #[Route('/api/abilities', name: 'ability_create', methods: ['POST'])]
+    public function __invoke(Request $request, HeroRepository $heroRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $hero = $heroRepository->find($data['hero'] ?? 0);
+        if (!$hero) {
+            return new JsonResponse(['error' => 'Hero not found'], 404);
+        }
+        $ability = new Ability();
+        $ability->setHero($hero)
+            ->setName($data['name'] ?? '')
+            ->setDescription($data['description'] ?? '')
+            ->setCooldown($data['cooldown'] ?? null)
+            ->setIconUrl($data['iconUrl'] ?? null);
+        $em->persist($ability);
+        $em->flush();
+        return new JsonResponse(['id' => $ability->getId()], 201);
+    }
+}

--- a/backend/src/Controller/Ability/DeleteAbilityController.php
+++ b/backend/src/Controller/Ability/DeleteAbilityController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\Ability;
+
+use App\Repository\AbilityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DeleteAbilityController extends AbstractController
+{
+    #[Route('/api/abilities/{id}', name: 'ability_delete', methods: ['DELETE'])]
+    public function __invoke(int $id, AbilityRepository $abilityRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $ability = $abilityRepository->find($id);
+        if (!$ability) {
+            return new JsonResponse(['error' => 'Ability not found'], 404);
+        }
+        $em->remove($ability);
+        $em->flush();
+        return new JsonResponse(['status' => 'deleted']);
+    }
+}

--- a/backend/src/Controller/Ability/ListAbilityController.php
+++ b/backend/src/Controller/Ability/ListAbilityController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller\Ability;
+
+use App\Repository\AbilityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ListAbilityController extends AbstractController
+{
+    #[Route('/api/abilities', name: 'ability_list', methods: ['GET'])]
+    public function __invoke(AbilityRepository $abilityRepository): JsonResponse
+    {
+        $abilities = $abilityRepository->findAll();
+        $data = [];
+        foreach ($abilities as $ability) {
+            $data[] = [
+                'id' => $ability->getId(),
+                'hero' => $ability->getHero()?->getId(),
+                'name' => $ability->getName(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+}

--- a/backend/src/Controller/Ability/ShowAbilityController.php
+++ b/backend/src/Controller/Ability/ShowAbilityController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controller\Ability;
+
+use App\Repository\AbilityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ShowAbilityController extends AbstractController
+{
+    #[Route('/api/abilities/{id}', name: 'ability_show', methods: ['GET'])]
+    public function __invoke(int $id, AbilityRepository $abilityRepository): JsonResponse
+    {
+        $ability = $abilityRepository->find($id);
+        if (!$ability) {
+            return new JsonResponse(['error' => 'Ability not found'], 404);
+        }
+        return new JsonResponse([
+            'id' => $ability->getId(),
+            'hero' => $ability->getHero()?->getId(),
+            'name' => $ability->getName(),
+            'description' => $ability->getDescription(),
+            'cooldown' => $ability->getCooldown(),
+            'iconUrl' => $ability->getIconUrl(),
+        ]);
+    }
+}

--- a/backend/src/Controller/Ability/UpdateAbilityController.php
+++ b/backend/src/Controller/Ability/UpdateAbilityController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Controller\Ability;
+
+use App\Repository\AbilityRepository;
+use App\Repository\HeroRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UpdateAbilityController extends AbstractController
+{
+    #[Route('/api/abilities/{id}', name: 'ability_update', methods: ['PUT'])]
+    public function __invoke(int $id, Request $request, AbilityRepository $abilityRepository, HeroRepository $heroRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $ability = $abilityRepository->find($id);
+        if (!$ability) {
+            return new JsonResponse(['error' => 'Ability not found'], 404);
+        }
+        $data = json_decode($request->getContent(), true);
+        if (isset($data['hero'])) {
+            $hero = $heroRepository->find($data['hero']);
+            if ($hero) {
+                $ability->setHero($hero);
+            }
+        }
+        if (isset($data['name'])) {
+            $ability->setName($data['name']);
+        }
+        if (isset($data['description'])) {
+            $ability->setDescription($data['description']);
+        }
+        if (array_key_exists('cooldown', $data)) {
+            $ability->setCooldown($data['cooldown']);
+        }
+        if (array_key_exists('iconUrl', $data)) {
+            $ability->setIconUrl($data['iconUrl']);
+        }
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/backend/src/Controller/Build/CreateBuildController.php
+++ b/backend/src/Controller/Build/CreateBuildController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Controller\Build;
+
+use App\Entity\Build;
+use App\Entity\BuildUpgrade;
+use App\Repository\HeroRepository;
+use App\Repository\UpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CreateBuildController extends AbstractController
+{
+    #[Route('/api/builds', name: 'build_create', methods: ['POST'])]
+    public function __invoke(Request $request, HeroRepository $heroRepository, UpgradeRepository $upgradeRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $hero = $heroRepository->find($data['hero'] ?? 0);
+        if (!$hero) {
+            return new JsonResponse(['error' => 'Hero not found'], 404);
+        }
+        $build = new Build();
+        $build->setUser($this->getUser())
+            ->setHero($hero)
+            ->setName($data['name'] ?? '')
+            ->setDescription($data['description'] ?? '')
+            ->setIsPublic($data['isPublic'] ?? false);
+        $em->persist($build);
+        if (!empty($data['items'])) {
+            foreach ($data['items'] as $itemData) {
+                $upgrade = $upgradeRepository->find($itemData['upgrade']);
+                if ($upgrade) {
+                    $bu = new BuildUpgrade();
+                    $bu->setBuild($build)
+                        ->setUpgrade($upgrade)
+                        ->setSlot($itemData['slot'] ?? 0);
+                    $em->persist($bu);
+                }
+            }
+        }
+        $em->flush();
+        return new JsonResponse(['id' => $build->getId()], 201);
+    }
+}

--- a/backend/src/Controller/Build/DeleteBuildController.php
+++ b/backend/src/Controller/Build/DeleteBuildController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Controller\Build;
+
+use App\Repository\BuildRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DeleteBuildController extends AbstractController
+{
+    #[Route('/api/builds/{id}', name: 'build_delete', methods: ['DELETE'])]
+    public function __invoke(int $id, BuildRepository $buildRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $build = $buildRepository->find($id);
+        if (!$build) {
+            return new JsonResponse(['error' => 'Build not found'], 404);
+        }
+        foreach ($build->getBuildUpgrades() as $bu) {
+            $em->remove($bu);
+        }
+        $em->remove($build);
+        $em->flush();
+        return new JsonResponse(['status' => 'deleted']);
+    }
+}

--- a/backend/src/Controller/Build/ListBuildController.php
+++ b/backend/src/Controller/Build/ListBuildController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller\Build;
+
+use App\Repository\BuildRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ListBuildController extends AbstractController
+{
+    #[Route('/api/builds', name: 'build_list', methods: ['GET'])]
+    public function __invoke(BuildRepository $buildRepository): JsonResponse
+    {
+        $builds = $buildRepository->findAll();
+        $data = [];
+        foreach ($builds as $build) {
+            $data[] = [
+                'id' => $build->getId(),
+                'name' => $build->getName(),
+                'hero' => $build->getHero()?->getId(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+}

--- a/backend/src/Controller/Build/ShowBuildController.php
+++ b/backend/src/Controller/Build/ShowBuildController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Controller\Build;
+
+use App\Repository\BuildRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ShowBuildController extends AbstractController
+{
+    #[Route('/api/builds/{id}', name: 'build_show', methods: ['GET'])]
+    public function __invoke(int $id, BuildRepository $buildRepository): JsonResponse
+    {
+        $build = $buildRepository->find($id);
+        if (!$build) {
+            return new JsonResponse(['error' => 'Build not found'], 404);
+        }
+        $items = [];
+        foreach ($build->getBuildUpgrades() as $bu) {
+            $items[] = [
+                'upgrade' => $bu->getUpgrade()->getId(),
+                'slot' => $bu->getSlot(),
+            ];
+        }
+        return new JsonResponse([
+            'id' => $build->getId(),
+            'name' => $build->getName(),
+            'hero' => $build->getHero()?->getId(),
+            'description' => $build->getDescription(),
+            'isPublic' => $build->isPublic(),
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/src/Controller/Build/UpdateBuildController.php
+++ b/backend/src/Controller/Build/UpdateBuildController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Controller\Build;
+
+use App\Repository\BuildRepository;
+use App\Repository\HeroRepository;
+use App\Repository\UpgradeRepository;
+use App\Entity\BuildUpgrade;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UpdateBuildController extends AbstractController
+{
+    #[Route('/api/builds/{id}', name: 'build_update', methods: ['PUT'])]
+    public function __invoke(int $id, Request $request, BuildRepository $buildRepository, HeroRepository $heroRepository, UpgradeRepository $upgradeRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $build = $buildRepository->find($id);
+        if (!$build) {
+            return new JsonResponse(['error' => 'Build not found'], 404);
+        }
+        $data = json_decode($request->getContent(), true);
+        if (isset($data['hero'])) {
+            $hero = $heroRepository->find($data['hero']);
+            if ($hero) {
+                $build->setHero($hero);
+            }
+        }
+        if (isset($data['name'])) {
+            $build->setName($data['name']);
+        }
+        if (isset($data['description'])) {
+            $build->setDescription($data['description']);
+        }
+        if (isset($data['isPublic'])) {
+            $build->setIsPublic($data['isPublic']);
+        }
+        if (isset($data['items'])) {
+            foreach ($build->getBuildUpgrades() as $existing) {
+                $em->remove($existing);
+            }
+            foreach ($data['items'] as $itemData) {
+                $upgrade = $upgradeRepository->find($itemData['upgrade']);
+                if ($upgrade) {
+                    $bu = new BuildUpgrade();
+                    $bu->setBuild($build)
+                        ->setUpgrade($upgrade)
+                        ->setSlot($itemData['slot'] ?? 0);
+                    $em->persist($bu);
+                }
+            }
+        }
+        $build->setUpdatedAt(new \DateTimeImmutable());
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/backend/src/Controller/BuildUpgrade/CreateBuildUpgradeController.php
+++ b/backend/src/Controller/BuildUpgrade/CreateBuildUpgradeController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Controller\BuildUpgrade;
+
+use App\Entity\BuildUpgrade;
+use App\Repository\BuildRepository;
+use App\Repository\UpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CreateBuildUpgradeController extends AbstractController
+{
+    #[Route('/api/build-upgrades', name: 'buildupgrade_create', methods: ['POST'])]
+    public function __invoke(Request $request, BuildRepository $buildRepository, UpgradeRepository $upgradeRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $build = $buildRepository->find($data['build'] ?? 0);
+        $upgrade = $upgradeRepository->find($data['upgrade'] ?? 0);
+        if (!$build || !$upgrade) {
+            return new JsonResponse(['error' => 'Invalid payload'], 400);
+        }
+        $bu = new BuildUpgrade();
+        $bu->setBuild($build)
+            ->setUpgrade($upgrade)
+            ->setSlot($data['slot'] ?? 0);
+        $em->persist($bu);
+        $em->flush();
+        return new JsonResponse(['id' => $bu->getId()], 201);
+    }
+}

--- a/backend/src/Controller/BuildUpgrade/DeleteBuildUpgradeController.php
+++ b/backend/src/Controller/BuildUpgrade/DeleteBuildUpgradeController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\BuildUpgrade;
+
+use App\Repository\BuildUpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DeleteBuildUpgradeController extends AbstractController
+{
+    #[Route('/api/build-upgrades/{id}', name: 'buildupgrade_delete', methods: ['DELETE'])]
+    public function __invoke(int $id, BuildUpgradeRepository $repository, EntityManagerInterface $em): JsonResponse
+    {
+        $bu = $repository->find($id);
+        if (!$bu) {
+            return new JsonResponse(['error' => 'Record not found'], 404);
+        }
+        $em->remove($bu);
+        $em->flush();
+        return new JsonResponse(['status' => 'deleted']);
+    }
+}

--- a/backend/src/Controller/BuildUpgrade/ListBuildUpgradeController.php
+++ b/backend/src/Controller/BuildUpgrade/ListBuildUpgradeController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Controller\BuildUpgrade;
+
+use App\Repository\BuildUpgradeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ListBuildUpgradeController extends AbstractController
+{
+    #[Route('/api/build-upgrades', name: 'buildupgrade_list', methods: ['GET'])]
+    public function __invoke(BuildUpgradeRepository $repository): JsonResponse
+    {
+        $records = $repository->findAll();
+        $data = [];
+        foreach ($records as $record) {
+            $data[] = [
+                'id' => $record->getId(),
+                'build' => $record->getBuild()?->getId(),
+                'upgrade' => $record->getUpgrade()?->getId(),
+                'slot' => $record->getSlot(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+}

--- a/backend/src/Controller/BuildUpgrade/ShowBuildUpgradeController.php
+++ b/backend/src/Controller/BuildUpgrade/ShowBuildUpgradeController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller\BuildUpgrade;
+
+use App\Repository\BuildUpgradeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ShowBuildUpgradeController extends AbstractController
+{
+    #[Route('/api/build-upgrades/{id}', name: 'buildupgrade_show', methods: ['GET'])]
+    public function __invoke(int $id, BuildUpgradeRepository $repository): JsonResponse
+    {
+        $record = $repository->find($id);
+        if (!$record) {
+            return new JsonResponse(['error' => 'Record not found'], 404);
+        }
+        return new JsonResponse([
+            'id' => $record->getId(),
+            'build' => $record->getBuild()?->getId(),
+            'upgrade' => $record->getUpgrade()?->getId(),
+            'slot' => $record->getSlot(),
+        ]);
+    }
+}

--- a/backend/src/Controller/BuildUpgrade/UpdateBuildUpgradeController.php
+++ b/backend/src/Controller/BuildUpgrade/UpdateBuildUpgradeController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller\BuildUpgrade;
+
+use App\Repository\BuildRepository;
+use App\Repository\BuildUpgradeRepository;
+use App\Repository\UpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UpdateBuildUpgradeController extends AbstractController
+{
+    #[Route('/api/build-upgrades/{id}', name: 'buildupgrade_update', methods: ['PUT'])]
+    public function __invoke(int $id, Request $request, BuildUpgradeRepository $repository, BuildRepository $buildRepository, UpgradeRepository $upgradeRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $bu = $repository->find($id);
+        if (!$bu) {
+            return new JsonResponse(['error' => 'Record not found'], 404);
+        }
+        $data = json_decode($request->getContent(), true);
+        if (isset($data['build'])) {
+            $build = $buildRepository->find($data['build']);
+            if ($build) {
+                $bu->setBuild($build);
+            }
+        }
+        if (isset($data['upgrade'])) {
+            $upgrade = $upgradeRepository->find($data['upgrade']);
+            if ($upgrade) {
+                $bu->setUpgrade($upgrade);
+            }
+        }
+        if (isset($data['slot'])) {
+            $bu->setSlot((int) $data['slot']);
+        }
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/backend/src/Controller/Hero/CreateHeroController.php
+++ b/backend/src/Controller/Hero/CreateHeroController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controller\Hero;
+
+use App\Entity\Hero;
+use App\Repository\HeroRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CreateHeroController extends AbstractController
+{
+    #[Route('/api/heroes', name: 'hero_create', methods: ['POST'])]
+    public function __invoke(Request $request, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $hero = new Hero();
+        $hero->setName($data['name'] ?? '')
+            ->setRole($data['role'] ?? '')
+            ->setDescription($data['description'] ?? '')
+            ->setImageUrl($data['imageUrl'] ?? null);
+        $em->persist($hero);
+        $em->flush();
+        return new JsonResponse(['id' => $hero->getId()], 201);
+    }
+}

--- a/backend/src/Controller/Hero/DeleteHeroController.php
+++ b/backend/src/Controller/Hero/DeleteHeroController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\Hero;
+
+use App\Repository\HeroRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DeleteHeroController extends AbstractController
+{
+    #[Route('/api/heroes/{id}', name: 'hero_delete', methods: ['DELETE'])]
+    public function __invoke(int $id, HeroRepository $heroRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $hero = $heroRepository->find($id);
+        if (!$hero) {
+            return new JsonResponse(['error' => 'Hero not found'], 404);
+        }
+        $em->remove($hero);
+        $em->flush();
+        return new JsonResponse(['status' => 'deleted']);
+    }
+}

--- a/backend/src/Controller/Hero/ListHeroController.php
+++ b/backend/src/Controller/Hero/ListHeroController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller\Hero;
+
+use App\Repository\HeroRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ListHeroController extends AbstractController
+{
+    #[Route('/api/heroes', name: 'hero_list', methods: ['GET'])]
+    public function __invoke(HeroRepository $heroRepository): JsonResponse
+    {
+        $heroes = $heroRepository->findAll();
+        $data = [];
+        foreach ($heroes as $hero) {
+            $data[] = [
+                'id' => $hero->getId(),
+                'name' => $hero->getName(),
+                'role' => $hero->getRole(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+}

--- a/backend/src/Controller/Hero/ShowHeroController.php
+++ b/backend/src/Controller/Hero/ShowHeroController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Controller\Hero;
+
+use App\Repository\HeroRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ShowHeroController extends AbstractController
+{
+    #[Route('/api/heroes/{id}', name: 'hero_show', methods: ['GET'])]
+    public function __invoke(int $id, HeroRepository $heroRepository): JsonResponse
+    {
+        $hero = $heroRepository->find($id);
+        if (!$hero) {
+            return new JsonResponse(['error' => 'Hero not found'], 404);
+        }
+        return new JsonResponse([
+            'id' => $hero->getId(),
+            'name' => $hero->getName(),
+            'role' => $hero->getRole(),
+            'description' => $hero->getDescription(),
+            'imageUrl' => $hero->getImageUrl(),
+        ]);
+    }
+}

--- a/backend/src/Controller/Hero/UpdateHeroController.php
+++ b/backend/src/Controller/Hero/UpdateHeroController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Controller\Hero;
+
+use App\Repository\HeroRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UpdateHeroController extends AbstractController
+{
+    #[Route('/api/heroes/{id}', name: 'hero_update', methods: ['PUT'])]
+    public function __invoke(int $id, Request $request, HeroRepository $heroRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $hero = $heroRepository->find($id);
+        if (!$hero) {
+            return new JsonResponse(['error' => 'Hero not found'], 404);
+        }
+        $data = json_decode($request->getContent(), true);
+        if (isset($data['name'])) {
+            $hero->setName($data['name']);
+        }
+        if (isset($data['role'])) {
+            $hero->setRole($data['role']);
+        }
+        if (isset($data['description'])) {
+            $hero->setDescription($data['description']);
+        }
+        if (array_key_exists('imageUrl', $data)) {
+            $hero->setImageUrl($data['imageUrl']);
+        }
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/backend/src/Controller/Upgrade/CreateUpgradeController.php
+++ b/backend/src/Controller/Upgrade/CreateUpgradeController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Controller\Upgrade;
+
+use App\Entity\Upgrade;
+use App\Repository\AbilityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CreateUpgradeController extends AbstractController
+{
+    #[Route('/api/upgrades', name: 'upgrade_create', methods: ['POST'])]
+    public function __invoke(Request $request, AbilityRepository $abilityRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $ability = $abilityRepository->find($data['ability'] ?? 0);
+        if (!$ability) {
+            return new JsonResponse(['error' => 'Ability not found'], 404);
+        }
+        $upgrade = new Upgrade();
+        $upgrade->setAbility($ability)
+            ->setName($data['name'] ?? '')
+            ->setDescription($data['description'] ?? '')
+            ->setCost($data['cost'] ?? 0)
+            ->setEffect($data['effect'] ?? []);
+        $em->persist($upgrade);
+        $em->flush();
+        return new JsonResponse(['id' => $upgrade->getId()], 201);
+    }
+}

--- a/backend/src/Controller/Upgrade/DeleteUpgradeController.php
+++ b/backend/src/Controller/Upgrade/DeleteUpgradeController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\Upgrade;
+
+use App\Repository\UpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DeleteUpgradeController extends AbstractController
+{
+    #[Route('/api/upgrades/{id}', name: 'upgrade_delete', methods: ['DELETE'])]
+    public function __invoke(int $id, UpgradeRepository $upgradeRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $upgrade = $upgradeRepository->find($id);
+        if (!$upgrade) {
+            return new JsonResponse(['error' => 'Upgrade not found'], 404);
+        }
+        $em->remove($upgrade);
+        $em->flush();
+        return new JsonResponse(['status' => 'deleted']);
+    }
+}

--- a/backend/src/Controller/Upgrade/ListUpgradeController.php
+++ b/backend/src/Controller/Upgrade/ListUpgradeController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller\Upgrade;
+
+use App\Repository\UpgradeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ListUpgradeController extends AbstractController
+{
+    #[Route('/api/upgrades', name: 'upgrade_list', methods: ['GET'])]
+    public function __invoke(UpgradeRepository $upgradeRepository): JsonResponse
+    {
+        $upgrades = $upgradeRepository->findAll();
+        $data = [];
+        foreach ($upgrades as $upgrade) {
+            $data[] = [
+                'id' => $upgrade->getId(),
+                'ability' => $upgrade->getAbility()?->getId(),
+                'name' => $upgrade->getName(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+}

--- a/backend/src/Controller/Upgrade/ShowUpgradeController.php
+++ b/backend/src/Controller/Upgrade/ShowUpgradeController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Controller\Upgrade;
+
+use App\Repository\UpgradeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ShowUpgradeController extends AbstractController
+{
+    #[Route('/api/upgrades/{id}', name: 'upgrade_show', methods: ['GET'])]
+    public function __invoke(int $id, UpgradeRepository $upgradeRepository): JsonResponse
+    {
+        $upgrade = $upgradeRepository->find($id);
+        if (!$upgrade) {
+            return new JsonResponse(['error' => 'Upgrade not found'], 404);
+        }
+        return new JsonResponse([
+            'id' => $upgrade->getId(),
+            'ability' => $upgrade->getAbility()?->getId(),
+            'name' => $upgrade->getName(),
+            'description' => $upgrade->getDescription(),
+            'cost' => $upgrade->getCost(),
+            'effect' => $upgrade->getEffect(),
+        ]);
+    }
+}

--- a/backend/src/Controller/Upgrade/UpdateUpgradeController.php
+++ b/backend/src/Controller/Upgrade/UpdateUpgradeController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Controller\Upgrade;
+
+use App\Repository\AbilityRepository;
+use App\Repository\UpgradeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UpdateUpgradeController extends AbstractController
+{
+    #[Route('/api/upgrades/{id}', name: 'upgrade_update', methods: ['PUT'])]
+    public function __invoke(int $id, Request $request, UpgradeRepository $upgradeRepository, AbilityRepository $abilityRepository, EntityManagerInterface $em): JsonResponse
+    {
+        $upgrade = $upgradeRepository->find($id);
+        if (!$upgrade) {
+            return new JsonResponse(['error' => 'Upgrade not found'], 404);
+        }
+        $data = json_decode($request->getContent(), true);
+        if (isset($data['ability'])) {
+            $ability = $abilityRepository->find($data['ability']);
+            if ($ability) {
+                $upgrade->setAbility($ability);
+            }
+        }
+        if (isset($data['name'])) {
+            $upgrade->setName($data['name']);
+        }
+        if (isset($data['description'])) {
+            $upgrade->setDescription($data['description']);
+        }
+        if (isset($data['cost'])) {
+            $upgrade->setCost((int) $data['cost']);
+        }
+        if (isset($data['effect'])) {
+            $upgrade->setEffect($data['effect']);
+        }
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+}

--- a/backend/src/Entity/Ability.php
+++ b/backend/src/Entity/Ability.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+#[ORM\Entity]
+class Ability
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Hero::class, inversedBy: 'abilities')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Hero $hero = null;
+
+    #[ORM\Column(length: 100)]
+    private string $name = '';
+
+    #[ORM\Column(type: 'text')]
+    private string $description = '';
+
+    #[ORM\Column(nullable: true)]
+    private ?int $cooldown = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?string $iconUrl = null;
+
+    #[ORM\OneToMany(mappedBy: 'ability', targetEntity: Upgrade::class, cascade: ['persist', 'remove'])]
+    private Collection $upgrades;
+
+    public function __construct()
+    {
+        $this->upgrades = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getHero(): ?Hero
+    {
+        return $this->hero;
+    }
+
+    public function setHero(?Hero $hero): self
+    {
+        $this->hero = $hero;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getCooldown(): ?int
+    {
+        return $this->cooldown;
+    }
+
+    public function setCooldown(?int $cooldown): self
+    {
+        $this->cooldown = $cooldown;
+        return $this;
+    }
+
+    public function getIconUrl(): ?string
+    {
+        return $this->iconUrl;
+    }
+
+    public function setIconUrl(?string $iconUrl): self
+    {
+        $this->iconUrl = $iconUrl;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Upgrade>
+     */
+    public function getUpgrades(): Collection
+    {
+        return $this->upgrades;
+    }
+
+    public function addUpgrade(Upgrade $upgrade): self
+    {
+        if (!$this->upgrades->contains($upgrade)) {
+            $this->upgrades->add($upgrade);
+            $upgrade->setAbility($this);
+        }
+
+        return $this;
+    }
+
+    public function removeUpgrade(Upgrade $upgrade): self
+    {
+        if ($this->upgrades->removeElement($upgrade)) {
+            if ($upgrade->getAbility() === $this) {
+                $upgrade->setAbility(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/Build.php
+++ b/backend/src/Entity/Build.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+#[ORM\Entity]
+class Build
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Hero::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Hero $hero = null;
+
+    #[ORM\Column(length: 100)]
+    private string $name = '';
+
+    #[ORM\Column(type: 'text')]
+    private string $description = '';
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $updatedAt;
+
+    #[ORM\Column]
+    private bool $isPublic = false;
+
+    #[ORM\OneToMany(mappedBy: 'build', targetEntity: BuildUpgrade::class, cascade: ['persist', 'remove'])]
+    private Collection $buildUpgrades;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+        $this->buildUpgrades = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getHero(): ?Hero
+    {
+        return $this->hero;
+    }
+
+    public function setHero(?Hero $hero): self
+    {
+        $this->hero = $hero;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->isPublic;
+    }
+
+    public function setIsPublic(bool $isPublic): self
+    {
+        $this->isPublic = $isPublic;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, BuildUpgrade>
+     */
+    public function getBuildUpgrades(): Collection
+    {
+        return $this->buildUpgrades;
+    }
+
+    public function addBuildUpgrade(BuildUpgrade $buildUpgrade): self
+    {
+        if (!$this->buildUpgrades->contains($buildUpgrade)) {
+            $this->buildUpgrades->add($buildUpgrade);
+            $buildUpgrade->setBuild($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBuildUpgrade(BuildUpgrade $buildUpgrade): self
+    {
+        if ($this->buildUpgrades->removeElement($buildUpgrade)) {
+            if ($buildUpgrade->getBuild() === $this) {
+                $buildUpgrade->setBuild(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/BuildUpgrade.php
+++ b/backend/src/Entity/BuildUpgrade.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class BuildUpgrade
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Build::class, inversedBy: 'buildUpgrades')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Build $build = null;
+
+    #[ORM\ManyToOne(targetEntity: Upgrade::class, inversedBy: 'buildUpgrades')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Upgrade $upgrade = null;
+
+    #[ORM\Column]
+    private int $slot = 0;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBuild(): ?Build
+    {
+        return $this->build;
+    }
+
+    public function setBuild(?Build $build): self
+    {
+        $this->build = $build;
+        return $this;
+    }
+
+    public function getUpgrade(): ?Upgrade
+    {
+        return $this->upgrade;
+    }
+
+    public function setUpgrade(?Upgrade $upgrade): self
+    {
+        $this->upgrade = $upgrade;
+        return $this;
+    }
+
+    public function getSlot(): int
+    {
+        return $this->slot;
+    }
+
+    public function setSlot(int $slot): self
+    {
+        $this->slot = $slot;
+        return $this;
+    }
+}

--- a/backend/src/Entity/Hero.php
+++ b/backend/src/Entity/Hero.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+#[ORM\Entity]
+class Hero
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 100)]
+    private string $name = '';
+
+    #[ORM\Column(length: 20)]
+    private string $role = '';
+
+    #[ORM\Column(type: 'text')]
+    private string $description = '';
+
+    #[ORM\Column(nullable: true)]
+    private ?string $imageUrl = null;
+
+    #[ORM\OneToMany(mappedBy: 'hero', targetEntity: Ability::class, cascade: ['persist', 'remove'])]
+    private Collection $abilities;
+
+    public function __construct()
+    {
+        $this->abilities = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function setRole(string $role): self
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl;
+    }
+
+    public function setImageUrl(?string $imageUrl): self
+    {
+        $this->imageUrl = $imageUrl;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Ability>
+     */
+    public function getAbilities(): Collection
+    {
+        return $this->abilities;
+    }
+
+    public function addAbility(Ability $ability): self
+    {
+        if (!$this->abilities->contains($ability)) {
+            $this->abilities->add($ability);
+            $ability->setHero($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAbility(Ability $ability): self
+    {
+        if ($this->abilities->removeElement($ability)) {
+            if ($ability->getHero() === $this) {
+                $ability->setHero(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/backend/src/Entity/Upgrade.php
+++ b/backend/src/Entity/Upgrade.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+#[ORM\Entity]
+class Upgrade
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Ability::class, inversedBy: 'upgrades')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Ability $ability = null;
+
+    #[ORM\Column(length: 100)]
+    private string $name = '';
+
+    #[ORM\Column(type: 'text')]
+    private string $description = '';
+
+    #[ORM\Column]
+    private int $cost = 0;
+
+    #[ORM\Column(type: 'json')]
+    private array $effect = [];
+
+    #[ORM\OneToMany(mappedBy: 'upgrade', targetEntity: BuildUpgrade::class, cascade: ['persist', 'remove'])]
+    private Collection $buildUpgrades;
+
+    public function __construct()
+    {
+        $this->buildUpgrades = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getAbility(): ?Ability
+    {
+        return $this->ability;
+    }
+
+    public function setAbility(?Ability $ability): self
+    {
+        $this->ability = $ability;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getCost(): int
+    {
+        return $this->cost;
+    }
+
+    public function setCost(int $cost): self
+    {
+        $this->cost = $cost;
+        return $this;
+    }
+
+    public function getEffect(): array
+    {
+        return $this->effect;
+    }
+
+    public function setEffect(array $effect): self
+    {
+        $this->effect = $effect;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, BuildUpgrade>
+     */
+    public function getBuildUpgrades(): Collection
+    {
+        return $this->buildUpgrades;
+    }
+
+    public function addBuildUpgrade(BuildUpgrade $buildUpgrade): self
+    {
+        if (!$this->buildUpgrades->contains($buildUpgrade)) {
+            $this->buildUpgrades->add($buildUpgrade);
+            $buildUpgrade->setUpgrade($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBuildUpgrade(BuildUpgrade $buildUpgrade): self
+    {
+        if ($this->buildUpgrades->removeElement($buildUpgrade)) {
+            if ($buildUpgrade->getUpgrade() === $this) {
+                $buildUpgrade->setUpgrade(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/backend/src/Repository/AbilityRepository.php
+++ b/backend/src/Repository/AbilityRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Ability;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Ability>
+ */
+class AbilityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Ability::class);
+    }
+}

--- a/backend/src/Repository/BuildRepository.php
+++ b/backend/src/Repository/BuildRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Build;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Build>
+ */
+class BuildRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Build::class);
+    }
+}

--- a/backend/src/Repository/BuildUpgradeRepository.php
+++ b/backend/src/Repository/BuildUpgradeRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\BuildUpgrade;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BuildUpgrade>
+ */
+class BuildUpgradeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BuildUpgrade::class);
+    }
+}

--- a/backend/src/Repository/HeroRepository.php
+++ b/backend/src/Repository/HeroRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Hero;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Hero>
+ */
+class HeroRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Hero::class);
+    }
+}

--- a/backend/src/Repository/UpgradeRepository.php
+++ b/backend/src/Repository/UpgradeRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Upgrade;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Upgrade>
+ */
+class UpgradeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Upgrade::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add Hero, Ability, Upgrade, Build and BuildUpgrade entities
- create repositories for new entities
- implement CRUD controllers with single-action classes for each entity

## Testing
- `php` is unavailable so syntax couldn't be validated

------
https://chatgpt.com/codex/tasks/task_e_684174777e84832e9c9a8a75d324d8ab