### PR TITLE
Add admin interface with login

### DIFF
--- a/webapp/cypress/e2e/example.cy.ts
+++ b/webapp/cypress/e2e/example.cy.ts
@@ -1,8 +1,8 @@
 // https://on.cypress.io/api
 
-describe('My First Test', () => {
+describe('Home Page', () => {
   it('visits the app root url', () => {
     cy.visit('/')
-    cy.contains('h1', 'You did it!')
+    cy.contains('h1', 'Bienvenue sur GameHub')
   })
 })

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>GameHub</title>
   </head>
   <body>
     <div id="app"></div>

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -1,85 +1,12 @@
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router'
-import HelloWorld from './components/HelloWorld.vue'
+import BaseHeader from './components/BaseHeader.vue'
+import BaseFooter from './components/BaseFooter.vue'
 </script>
 
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="@/assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-
-      <nav>
-        <RouterLink to="/">Home</RouterLink>
-        <RouterLink to="/about">About</RouterLink>
-      </nav>
-    </div>
-  </header>
-
-  <RouterView />
+  <BaseHeader />
+  <main class="container mx-auto py-8">
+    <RouterView />
+  </main>
+  <BaseFooter />
 </template>
-
-<style scoped>
-header {
-  line-height: 1.5;
-  max-height: 100vh;
-}
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-nav {
-  width: 100%;
-  font-size: 12px;
-  text-align: center;
-  margin-top: 2rem;
-}
-
-nav a.router-link-exact-active {
-  color: var(--color-text);
-}
-
-nav a.router-link-exact-active:hover {
-  background-color: transparent;
-}
-
-nav a {
-  display: inline-block;
-  padding: 0 1rem;
-  border-left: 1px solid var(--color-border);
-}
-
-nav a:first-of-type {
-  border: 0;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  nav {
-    text-align: left;
-    margin-left: -1rem;
-    font-size: 1rem;
-
-    padding: 1rem 0;
-    margin-top: 1rem;
-  }
-}
-</style>

--- a/webapp/src/assets/main.scss
+++ b/webapp/src/assets/main.scss
@@ -3,37 +3,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  font-weight: normal;
-}
-
-a,
-.green {
-  text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
-  transition: 0.4s;
-  padding: 3px;
-}
-
-@media (hover: hover) {
-  a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
-  }
-}
-
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-  }
-}

--- a/webapp/src/components/BaseFooter.vue
+++ b/webapp/src/components/BaseFooter.vue
@@ -1,0 +1,5 @@
+<template>
+  <footer class="bg-gray-800 text-white text-center p-4 mt-8">
+    © 2024 GameHub
+  </footer>
+</template>

--- a/webapp/src/components/BaseHeader.vue
+++ b/webapp/src/components/BaseHeader.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import { useUserStore } from '../stores/user'
+const user = useUserStore()
+</script>
+
+<template>
+  <header class="bg-gray-800 text-white p-4">
+    <nav class="container mx-auto flex justify-between items-center">
+      <div class="flex space-x-4">
+        <RouterLink class="hover:underline" to="/">Accueil</RouterLink>
+        <RouterLink class="hover:underline" to="/about">À propos</RouterLink>
+        <RouterLink
+          v-if="user.isAdmin"
+          class="hover:underline"
+          to="/admin"
+        >Administration</RouterLink>
+      </div>
+      <div>
+        <RouterLink v-if="!user.isLogged" to="/login" class="hover:underline"
+          >Connexion</RouterLink>
+        <button
+          v-else
+          @click="user.logout()"
+          class="hover:underline"
+        >Se déconnecter</button>
+      </div>
+    </nav>
+  </header>
+</template>

--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -1,23 +1,24 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import { useUserStore } from '../stores/user'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: HomeView,
-    },
-    {
-      path: '/about',
-      name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import('../views/AboutView.vue'),
-    },
+    { path: '/', name: 'home', component: HomeView },
+    { path: '/about', name: 'about', component: () => import('../views/AboutView.vue') },
+    { path: '/login', name: 'login', component: () => import('../views/LoginView.vue') },
+    { path: '/admin', name: 'admin', component: () => import('../views/AdminView.vue'), meta: { requiresAdmin: true } },
   ],
+})
+
+router.beforeEach((to, from, next) => {
+  const store = useUserStore()
+  if (to.meta.requiresAdmin && !store.isAdmin) {
+    next('/login')
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/webapp/src/stores/user.ts
+++ b/webapp/src/stores/user.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export interface UserInfo {
+  id: number
+  email: string
+  roles: string[]
+}
+
+export const useUserStore = defineStore('user', () => {
+  const token = ref<string | null>(localStorage.getItem('token'))
+  const user = ref<UserInfo | null>(null)
+
+  const isLogged = computed(() => !!token.value)
+  const isAdmin = computed(() => user.value?.roles.includes('ROLE_ADMIN'))
+
+  async function fetchMe() {
+    if (!token.value) return
+    const res = await fetch('/api/me', {
+      headers: { Authorization: `Bearer ${token.value}` },
+    })
+    if (res.ok) {
+      user.value = await res.json()
+    }
+  }
+
+  async function login(email: string, password: string) {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (!res.ok) {
+      return false
+    }
+    const data = await res.json()
+    token.value = data.token
+    localStorage.setItem('token', token.value!)
+    await fetchMe()
+    return true
+  }
+
+  function logout() {
+    token.value = null
+    user.value = null
+    localStorage.removeItem('token')
+  }
+
+  if (token.value) {
+    fetchMe()
+  }
+
+  return { token, user, isLogged, isAdmin, login, logout, fetchMe }
+})

--- a/webapp/src/views/AdminView.vue
+++ b/webapp/src/views/AdminView.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useUserStore } from '../stores/user'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const store = useUserStore()
+if (!store.isAdmin) {
+  router.push('/')
+}
+
+const entities = ['heroes', 'abilities', 'upgrades', 'builds', 'build-upgrades', 'users']
+const current = ref('heroes')
+const list = ref<any[]>([])
+const newItem = ref<any>({})
+
+watch(current, () => fetchList())
+fetchList()
+
+async function fetchList() {
+  const res = await fetch(`/api/${current.value}`, {
+    headers: { Authorization: `Bearer ${store.token}` },
+  })
+  if (res.ok) {
+    list.value = await res.json()
+  } else {
+    list.value = []
+  }
+  newItem.value = {}
+}
+
+async function createItem() {
+  const res = await fetch(`/api/${current.value}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${store.token}`,
+    },
+    body: JSON.stringify(newItem.value),
+  })
+  if (res.ok) {
+    await fetchList()
+  } else {
+    alert('Erreur lors de la création')
+  }
+}
+
+async function deleteItem(id: number) {
+  const res = await fetch(`/api/${current.value}/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${store.token}` },
+  })
+  if (res.ok) {
+    await fetchList()
+  }
+}
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-4">Administration</h1>
+    <div class="mb-4">
+      <label>Entité : </label>
+      <select v-model="current" class="border p-1 rounded">
+        <option v-for="e in entities" :key="e" :value="e">{{ e }}</option>
+      </select>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <div>
+        <h2 class="font-semibold mb-2">Liste</h2>
+        <table class="min-w-full text-sm text-left">
+          <thead>
+            <tr>
+              <th v-for="(val, key) in list[0] || {}" :key="key" class="border px-2">{{ key }}</th>
+              <th class="border px-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in list" :key="item.id">
+              <td v-for="(val, key) in item" :key="key" class="border px-2">{{ val }}</td>
+              <td class="border px-2">
+                <button class="text-red-600" @click="deleteItem(item.id)">Supprimer</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2 class="font-semibold mb-2">Ajouter</h2>
+        <form @submit.prevent="createItem" class="space-y-2">
+          <textarea v-model="newItem" placeholder='{ "name": "..." }' class="w-full border p-2 rounded" rows="6"></textarea>
+          <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Enregistrer</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>

--- a/webapp/src/views/HomeView.vue
+++ b/webapp/src/views/HomeView.vue
@@ -1,9 +1,6 @@
-<script setup lang="ts">
-import TheWelcome from '../components/TheWelcome.vue'
-</script>
-
 <template>
-  <main>
-    <TheWelcome />
-  </main>
+  <div class="text-center">
+    <h1 class="text-3xl font-bold mb-4">Bienvenue sur GameHub</h1>
+    <p>Gestion de builds Overwatch 2 Stadium.</p>
+  </div>
 </template>

--- a/webapp/src/views/LoginView.vue
+++ b/webapp/src/views/LoginView.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useUserStore } from '../stores/user'
+
+const email = ref('')
+const password = ref('')
+const router = useRouter()
+const user = useUserStore()
+
+async function handleLogin() {
+  const ok = await user.login(email.value, password.value)
+  if (ok) {
+    router.push('/')
+  } else {
+    alert('Identifiants incorrects')
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-overwatch flex items-center justify-center p-4">
+    <div class="absolute inset-0 bg-black bg-opacity-40"></div>
+    <div class="relative z-10 w-full max-w-6xl mx-auto">
+      <div class="bg-white bg-opacity-10 backdrop-blur-lg rounded-3xl shadow-2xl border border-white border-opacity-20 overflow-hidden">
+        <div class="grid lg:grid-cols-2 min-h-[600px]">
+          <div class="flex flex-col justify-center items-center text-center p-12 lg:p-16 bg-gradient-to-br from-white/10 to-transparent">
+            <div class="text-8xl mb-8 float-animation">🎮</div>
+            <h1 class="text-4xl lg:text-5xl font-bold text-white mb-6 drop-shadow-lg leading-tight">
+              Prêt pour l'arène ?
+            </h1>
+            <p class="text-xl text-white/90 font-light drop-shadow-md max-w-md">
+              Rejoins la bataille et montre tes talents de gamer !
+            </p>
+            <div class="flex space-x-4 mt-8 opacity-70">
+              <div class="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+              <div class="w-2 h-2 bg-white rounded-full animate-pulse" style="animation-delay: 0.5s;"></div>
+              <div class="w-2 h-2 bg-white rounded-full animate-pulse" style="animation-delay: 1s;"></div>
+            </div>
+          </div>
+          <div class="bg-white bg-opacity-95 backdrop-blur-sm p-12 lg:p-16 flex flex-col justify-center">
+            <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">
+              Connexion
+            </h2>
+            <form class="space-y-6" @submit.prevent="handleLogin">
+              <div class="space-y-2">
+                <label for="email" class="block text-sm font-medium text-gray-700">Adresse email</label>
+                <input v-model="email" type="email" id="email" required class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:ring-2 focus:ring-blue-200 transition-all duration-300 bg-gray-50 focus:bg-white text-gray-800" placeholder="exemple@email.com" />
+              </div>
+              <div class="space-y-2">
+                <label for="password" class="block text-sm font-medium text-gray-700">Mot de passe</label>
+                <input v-model="password" type="password" id="password" required class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:ring-2 focus:ring-blue-200 transition-all duration-300 bg-gray-50 focus:bg-white text-gray-800" placeholder="••••••••" />
+              </div>
+              <div class="flex items-center justify-between text-sm">
+                <label class="flex items-center text-gray-600">
+                  <input type="checkbox" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" />
+                  <span class="ml-2">Se souvenir de moi</span>
+                </label>
+              </div>
+              <button type="submit" class="w-full bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold py-4 px-6 rounded-xl hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-300 shadow-lg glow-animation">
+                Se connecter
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style>
+.bg-overwatch {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQwMCIgaGVpZ2h0PSI4MDAiIHZpZXdCb3g9IjAgMCAxNDAwIDgwMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE0MDAiIGhlaWdodD0iODAwIiBmaWxsPSJ1cmwoI3BhaW50MF9saW5lYXJfMF8xKSIvPgo8ZGVmcz4KPGxpbmVhckdyYWRpZW50IGlkPSJwYWludDBfbGluZWFyXzBfMSIgeDE9IjAiIHkxPSIwIiB4Mj0iMTQwMCIgeTI9IjgwMCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjRkY3MDQzIi8+CjxzdG9wIG9mZnNldD0iMC41IiBzdG9wLWNvbG9yPSIjRkY5NTAwIi8+CjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI0ZGNjUwMCIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM+Cjwvc3ZnPgo=');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-10px); }
+}
+
+.float-animation {
+  animation: float 3s ease-in-out infinite;
+}
+
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 20px rgba(59, 130, 246, 0.5); }
+  50% { box-shadow: 0 0 30px rgba(59, 130, 246, 0.8); }
+}
+
+.glow-animation {
+  animation: glow 2s ease-in-out infinite;
+}
+</style>


### PR DESCRIPTION
## Summary
- create Pinia user store for JWT auth
- add header/footer components with Tailwind styling
- redesign App layout with header and footer
- add login page and simple admin view
- route login and admin, guard admin route
- simplify home page and update Cypress test
- cleanup default CSS

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: server start but cypress didn't run)*

------
https://chatgpt.com/codex/tasks/task_e_68420e036b28832ead5d8dff31b20616